### PR TITLE
[Mac] Fix app not restarting on update

### DIFF
--- a/packages/@ledgerhq/electron-updater/src/MacUpdater.ts
+++ b/packages/@ledgerhq/electron-updater/src/MacUpdater.ts
@@ -81,7 +81,6 @@ export class MacUpdater extends BaseUpdater {
             if (!errorOccurred) {
               this.nativeUpdater.removeListener("error", reject)
             }
-            resolve(false)
           }
         })
 


### PR DESCRIPTION
My makeshift updater wrapper was resolving `false` before even letting the chance to the native one to give the actual result, thus breaking the UI into staying stuck in a "not yet installed" state (and not the "failed" state since not rejecting nor throwing).

This should fix that ©